### PR TITLE
Bundle status for install / update

### DIFF
--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -50,7 +50,7 @@ declare-option -hidden str bundle_sh_code %{
             touch "$tmp_dir"/.rmme  # safeguard
         fi
         tmp_cnt=$(( tmp_cnt + 1 ))
-        tmp_file=$tmp_dir/bundle-$(printf '%05d' "$tmp_cnt").${1:-tmp}
+        tmp_file=$tmp_dir/bundle-"$tmp_cnt.${1:-tmp}"
     }
     bundle_tmp_clean() {
         if "$kak_opt_bundle_parallel"; then

--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -68,7 +68,7 @@ declare-option -hidden str bundle_sh_code %{
             "$2" || return 0
             status="%file<$1.log>"
         fi
-        printf 'bundle-status-log-load %s%s%s %s\n' '%<' "$1" '>' "$status"
+        printf 'bundle-status-log-load %%file<%s.pwd> %%file<%s.cmd> %s\n' "$1" "$1" "$status"
     }
     bundle_job_chk() {
         set -- "$tmp_dir"/*.job.running
@@ -92,7 +92,7 @@ declare-option -hidden str bundle_sh_code %{
         [ -n "$tmp_dir" ] || return 0
         while :; do
             {
-            printf '%s\n' 'set global bundle_log %{}; edit -scratch *bundle-status*'
+            printf '%s\n' 'edit -scratch *bundle-status*; set buffer bundle_log %{}'
             running=0
             set -- "$tmp_dir"/*.job.log
             for finished in true false; do  # running jobs -> bottom
@@ -165,13 +165,10 @@ define-command bundle -params 1 -docstring "Tells kak-bundle to manage this plug
 }
 
 declare-option -hidden str bundle_log
-define-command bundle-status-log-load -params 2 -docstring %{
+define-command bundle-status-log-load -params 3 -docstring %{
 } %{
-    set -add global bundle_log "## in <"
-    eval set -add global bundle_log "%%file<%arg{1}.pwd>"
-    set -add global bundle_log '>: '
-    eval set -add global bundle_log "%%file<%arg{1}.cmd>"
-    set -add global bundle_log %arg{2}
+    buffer *bundle-status*
+    set -add buffer bundle_log "## in <%arg{1}>: %arg{2}%arg{3}"
 } -hidden
 
 define-command bundle-status-log-show -params 1 -docstring %{
@@ -185,7 +182,7 @@ define-command bundle-status-log-show -params 1 -docstring %{
         reg dquote "(%arg{1} running)"
         exec %{<a-o>} %{geP}
     }
-}
+} -hidden
 
 define-command bundle-install -docstring "Install all plugins known to kak-bundle." %{
     eval -- %sh{

--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -165,7 +165,9 @@ define-command bundle-status-update-hook -params .. -docstring %{
                 'nop %sh{bundle_tmp_clean}'  # run from kak AFTER finishing up
         fi
     }
-    exec HLHL  # trigger another hook later
+    hook -once -group bundle-status buffer NormalIdle .* %{
+        exec HLHL
+    }  # re-trigger
 } -hidden
 define-command bundle-status-log-load -params 4 -docstring %{
 } %{

--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -160,7 +160,8 @@ define-command bundle-status-update-hook -params .. -docstring %{
             printf >&3 '%s\n' \
                 'rmhooks buffer bundle-status' \
                 'set buffer bundle_tmp_dir %{}' \
-                'exec %{ge} %{o} %{DONE} %{<esc>}' \
+                'map buffer normal <esc> %{: delete-buffer *bundle-status*<ret>}' \
+                'exec %{ge} %{o} %{DONE (<} %{esc} %{> = dismiss)} %{<esc>}' \
                 'nop %sh{bundle_tmp_clean}'  # run from kak AFTER finishing up
         fi
     }

--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -25,16 +25,13 @@ declare-option -hidden str bundle_sh_code %{
 '
     vvc() {  # execute command, maybe print beforehand, maybe background
         ! "$kak_opt_bundle_verbose" || printf 'bundle: executing %s\n' "$*" 1>&2
-        if "$kak_opt_bundle_parallel"; then
-            bundle_tmp_new job
-            printf '%s\n' "$*" >"$tmp_file".cmd
-            printf '%s' "$PWD" >"$tmp_file".pwd
+        bundle_tmp_new job
+        printf '%s\n' "$*" >"$tmp_file".cmd
+        printf '%s' "$PWD" >"$tmp_file".pwd
 
-            > "$tmp_file.running"; >"$tmp_file".log
-            ( ( "$@" ); rm -f "$tmp_file.running" ) >"$tmp_file".log 2>&1 3>&- &
-        else
-            "$@"
-        fi
+        > "$tmp_file.running"; >"$tmp_file".log
+        ( ( "$@" ); rm -f "$tmp_file.running" ) >"$tmp_file".log 2>&1 3>&- &
+        "$kak_opt_bundle_parallel" || bundle_tmp_log_wait
     }
     bundle_cd() {  # cd to bundle_path, create if missing
         [ -d "$kak_opt_bundle_path" ] || mkdir -p "$kak_opt_bundle_path"
@@ -167,7 +164,7 @@ define-command bundle-status-log-show -params 1 -docstring %{
         exec %{%"_d}
         reg dquote %opt{bundle_log}
         exec %{P}
-        reg dquote "(%arg{1} left)"
+        reg dquote "(%arg{1} running)"
         exec %{2<a-o>} %{geP}
     }
 }

--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -210,7 +210,6 @@ define-command bundle-install -docstring "Install all plugins known to kak-bundl
         > "$tmp_dir"/.done
         ) >/dev/null 2>&1 3>&- &
     }
-    echo "kak-bundle: bundle-install completed"
 }
 
 define-command bundle-clean -docstring "Remove all currently installed plugins." %{
@@ -228,10 +227,7 @@ define-command bundle-update -docstring "Update all currently installed plugins.
         for dir in "$kak_opt_bundle_path"/*
         do
             if ! [ -h "$dir" ] && cd "$dir" 2>/dev/null; then
-                ! "$kak_opt_bundle_verbose" || printf '%s\n' "bundle: updating in $PWD ..." 1>&2
                 vvc git pull $kak_opt_bundle_git_shallow_opts
-            else
-                ! "$kak_opt_bundle_verbose" || printf '%s\n' "bundle: skipping $dir ..." 1>&2
             fi
         done
         bundle_tmp_log_wait

--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -80,11 +80,6 @@ declare-option -hidden str bundle_sh_code %{
             sleep 1
         done
     }
-    bundle_tmp_clean() {
-        if [ -n "$tmp_dir" ] && [ -e "$tmp_dir"/.rmme ]; then
-            rm -Rf "$tmp_dir"
-        fi
-    }
     bundle_status_init() {
         bundle_tmp_new  # ensure tmp_dir exists
         printf >&3 '%s\n' \
@@ -159,10 +154,13 @@ define-command bundle-status-update-hook -params .. -docstring %{
         if [ -e "$tmp_dir/.done" ]; then
             printf >&3 '%s\n' \
                 'rmhooks buffer bundle-status' \
-                'set buffer bundle_tmp_dir %{}' \
                 'map buffer normal <esc> %{: delete-buffer *bundle-status*<ret>}' \
                 'exec %{ge} %{o} %{DONE (<} %{esc} %{> = dismiss)} %{<esc>}' \
-                'nop %sh{bundle_tmp_clean}'  # run from kak AFTER finishing up
+                'nop -- %sh{
+                    set -- "$kak_opt_bundle_tmp_dir"
+                    if [ -n "$1" ] && [ -e "$1"/.rmme ]; then rm -Rf "$1"; fi
+                }' \
+                'set buffer bundle_tmp_dir %{}'
         fi
     }
     hook -once -group bundle-status buffer NormalIdle .* %{

--- a/rc/kak-bundle.kak
+++ b/rc/kak-bundle.kak
@@ -36,7 +36,7 @@ declare-option -hidden str bundle_sh_code %{
         > "$tmp_file.running"; >"$tmp_file".log
         ( ( "$@" ); rm -f "$tmp_file.running" ) >"$tmp_file".log 2>&1 3>&- &
 
-        set -- "$tmp_dir"/*.job.running; [ -e "$1" ] || set --
+        set -- "$tmp_dir"/*.job.running; [ $# != 1 ] || [ -e "$1" ] || set --
         [ $# -lt "$kak_opt_bundle_parallel" ] || wait $!
     }
     bundle_cd() {  # cd to bundle_path, create if missing
@@ -75,7 +75,7 @@ declare-option -hidden str bundle_sh_code %{
     bundle_tmp_log_wait() {
         [ -n "$tmp_dir" ] || return 0
         while :; do
-            set -- "$tmp_dir"/*.job.running; [ -e "$1" ] || set --
+            set -- "$tmp_dir"/*.job.running; [ $# != 1 ] || [ -e "$1" ] || set --
             [ $# != 0 ] || break
             sleep 1
         done


### PR DESCRIPTION
Phew, this was quite a bit of work, but it looks really, really nice. If you have questions about the decisions in my code, let me know.

I've tried `command_fifo` for a while, but it has some pretty serious bugs (https://github.com/mawww/kakoune/issues/4410). Thus I switched to implementing a "periodic hook" for `*bundle-status*`, which turned out to be pretty simple, elegant, non-blocking for the user, and *much* less complex on top of that. However, having some `command_fifo` code in `git` history might be useful for the future (as well as for debugging `kak`); thus I didn't remove it.

`bundle_parallel` is now an `int` controlling the maximum number of parallel jobs. It had to be done, after all we don't want 100 `git clone / pull`'s running.